### PR TITLE
#32 중복된 Status enum 중복 제거 및 code inpsect 후 수정

### DIFF
--- a/src/main/java/com/younghun/hibusgo/controller/LoginController.java
+++ b/src/main/java/com/younghun/hibusgo/controller/LoginController.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/younghun/hibusgo/domain/Account.java
+++ b/src/main/java/com/younghun/hibusgo/domain/Account.java
@@ -12,14 +12,6 @@ import lombok.ToString;
 @ToString
 public class Account {
 
-    public enum Status {
-        // 기본
-        DEFAULT,
-
-        // 삭제됨
-        DELETED
-    }
-
     // 아이디(pk)
     private long id;
 

--- a/src/main/java/com/younghun/hibusgo/domain/Account.java
+++ b/src/main/java/com/younghun/hibusgo/domain/Account.java
@@ -31,7 +31,7 @@ public class Account {
     private UserLevel userLevel;
 
     // 회원 상태 DEFAULT(기본), DELETED(삭제됨)
-    private Status status;
+    private DataStatus status;
 
     // 회원가입일
     private LocalDateTime createdAt;

--- a/src/main/java/com/younghun/hibusgo/domain/BusTerminal.java
+++ b/src/main/java/com/younghun/hibusgo/domain/BusTerminal.java
@@ -20,14 +20,6 @@ import lombok.ToString;
 @ToString
 public class BusTerminal {
 
-    public enum Status {
-        // 기본
-        DEFAULT,
-
-        // 삭제됨
-        DELETED
-    }
-
     //아이디
     private int id;
 

--- a/src/main/java/com/younghun/hibusgo/domain/BusTerminal.java
+++ b/src/main/java/com/younghun/hibusgo/domain/BusTerminal.java
@@ -36,5 +36,5 @@ public class BusTerminal {
     private String region;
 
     // 버스 터미널 상태 DEFAULT(기본), DELETED(삭제됨)
-    private Status status;
+    private DataStatus status;
 }

--- a/src/main/java/com/younghun/hibusgo/domain/DataStatus.java
+++ b/src/main/java/com/younghun/hibusgo/domain/DataStatus.java
@@ -1,6 +1,6 @@
 package com.younghun.hibusgo.domain;
 
-public enum Status {
+public enum DataStatus {
   // 기본
   DEFAULT,
 

--- a/src/main/java/com/younghun/hibusgo/domain/Region.java
+++ b/src/main/java/com/younghun/hibusgo/domain/Region.java
@@ -20,5 +20,5 @@ public class Region {
     private String name;
 
     // 지역 상태(기본, 삭제)
-    private Status status;
+    private DataStatus status;
 }

--- a/src/main/java/com/younghun/hibusgo/domain/Region.java
+++ b/src/main/java/com/younghun/hibusgo/domain/Region.java
@@ -13,10 +13,6 @@ import lombok.ToString;
 @ToString
 public class Region {
 
-    public enum Status {
-        DEFAULT, DELETED
-    }
-
     //지역 아이디
     private int id;
 

--- a/src/main/java/com/younghun/hibusgo/domain/Status.java
+++ b/src/main/java/com/younghun/hibusgo/domain/Status.java
@@ -1,0 +1,9 @@
+package com.younghun.hibusgo.domain;
+
+public enum Status {
+  // 기본
+  DEFAULT,
+
+  // 삭제됨
+  DELETED
+}

--- a/src/main/java/com/younghun/hibusgo/dto/AccountDto.java
+++ b/src/main/java/com/younghun/hibusgo/dto/AccountDto.java
@@ -2,7 +2,7 @@ package com.younghun.hibusgo.dto;
 
 import com.younghun.hibusgo.aop.LoginCheck.UserLevel;
 import com.younghun.hibusgo.domain.Account;
-import com.younghun.hibusgo.domain.Status;
+import com.younghun.hibusgo.domain.DataStatus;
 import javax.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,7 +46,7 @@ public class AccountDto {
     private UserLevel userLevel;
 
     // 상태 DEFAULT(기본), DELETED(삭제됨)
-    private Status status;
+    private DataStatus status;
 
     public Account toEntity() {
         return Account.builder()
@@ -55,7 +55,7 @@ public class AccountDto {
                 .name(this.name)
                 .phoneNumber(this.phoneNumber)
                 .userLevel(UserLevel.USER)
-                .status(Status.DEFAULT)
+                .status(DataStatus.DEFAULT)
                 .build();
     }
 

--- a/src/main/java/com/younghun/hibusgo/dto/AccountDto.java
+++ b/src/main/java/com/younghun/hibusgo/dto/AccountDto.java
@@ -2,7 +2,7 @@ package com.younghun.hibusgo.dto;
 
 import com.younghun.hibusgo.aop.LoginCheck.UserLevel;
 import com.younghun.hibusgo.domain.Account;
-import com.younghun.hibusgo.domain.Account.Status;
+import com.younghun.hibusgo.domain.Status;
 import javax.validation.constraints.Max;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/younghun/hibusgo/dto/BusTerminalDto.java
+++ b/src/main/java/com/younghun/hibusgo/dto/BusTerminalDto.java
@@ -1,7 +1,7 @@
 package com.younghun.hibusgo.dto;
 
 import com.younghun.hibusgo.domain.BusTerminal;
-import com.younghun.hibusgo.domain.Status;
+import com.younghun.hibusgo.domain.DataStatus;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
@@ -33,7 +33,7 @@ public class BusTerminalDto {
     private String region;
 
     // 버스 미널 상태 DEFAULT(기본), DELETED(삭제됨)
-    private Status status;
+    private DataStatus status;
 
     public BusTerminal toEntity() {
         return BusTerminal.builder()
@@ -41,7 +41,7 @@ public class BusTerminalDto {
             .address(this.address)
             .tel(this.tel)
             .region(this.region)
-            .status(Status.DEFAULT)
+            .status(DataStatus.DEFAULT)
             .build();
     }
 }

--- a/src/main/java/com/younghun/hibusgo/dto/BusTerminalDto.java
+++ b/src/main/java/com/younghun/hibusgo/dto/BusTerminalDto.java
@@ -1,8 +1,7 @@
 package com.younghun.hibusgo.dto;
 
 import com.younghun.hibusgo.domain.BusTerminal;
-import com.younghun.hibusgo.domain.BusTerminal.Status;
-import javax.validation.constraints.Max;
+import com.younghun.hibusgo.domain.Status;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/younghun/hibusgo/dto/LoginDto.java
+++ b/src/main/java/com/younghun/hibusgo/dto/LoginDto.java
@@ -5,7 +5,6 @@ package com.younghun.hibusgo.dto;
 import lombok.AllArgsConstructor;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Max;
 import javax.validation.constraints.Pattern;
 
 import lombok.Builder;

--- a/src/main/java/com/younghun/hibusgo/dto/RegionDto.java
+++ b/src/main/java/com/younghun/hibusgo/dto/RegionDto.java
@@ -1,8 +1,8 @@
 package com.younghun.hibusgo.dto;
 
 
+import com.younghun.hibusgo.domain.DataStatus;
 import com.younghun.hibusgo.domain.Region;
-import com.younghun.hibusgo.domain.Status;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +24,7 @@ public class RegionDto {
     public Region toEntity() {
         return Region.builder()
             .name(this.name)
-            .status(Status.DEFAULT)
+            .status(DataStatus.DEFAULT)
             .build();
     }
 

--- a/src/main/java/com/younghun/hibusgo/dto/RegionDto.java
+++ b/src/main/java/com/younghun/hibusgo/dto/RegionDto.java
@@ -2,7 +2,7 @@ package com.younghun.hibusgo.dto;
 
 
 import com.younghun.hibusgo.domain.Region;
-import com.younghun.hibusgo.domain.Region.Status;
+import com.younghun.hibusgo.domain.Status;
 import javax.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/younghun/hibusgo/service/AccountService.java
+++ b/src/main/java/com/younghun/hibusgo/service/AccountService.java
@@ -2,7 +2,7 @@ package com.younghun.hibusgo.service;
 
 
 import com.younghun.hibusgo.domain.Account;
-import com.younghun.hibusgo.domain.Account.Status;
+import com.younghun.hibusgo.domain.DataStatus;
 import com.younghun.hibusgo.mapper.AccountMapper;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +38,7 @@ public class AccountService {
         String encodePassword = passwordEncoder.encode(password);
 
         return Optional.ofNullable(accountMapper.findByUserIdAndPassword(userId, encodePassword))
-            .filter(o -> o.getStatus() == Status.DEFAULT);
+            .filter(o -> o.getStatus() == DataStatus.DEFAULT);
     }
 
     public void deleteAccount(long id) {

--- a/src/main/java/com/younghun/hibusgo/service/BusTerminalService.java
+++ b/src/main/java/com/younghun/hibusgo/service/BusTerminalService.java
@@ -2,7 +2,7 @@ package com.younghun.hibusgo.service;
 
 
 import com.younghun.hibusgo.domain.BusTerminal;
-import com.younghun.hibusgo.domain.Status;
+import com.younghun.hibusgo.domain.DataStatus;
 import com.younghun.hibusgo.mapper.BusTerminalMapper;
 import java.util.List;
 import java.util.Optional;
@@ -31,7 +31,7 @@ public class BusTerminalService {
     @Cacheable(value = "terminals.name", key = "#name", cacheManager = "redisCacheManager")
     public Optional<BusTerminal> findByNameAndRegion(String name, String region) {
         return Optional.ofNullable(terminalMapper.findByNameAndRegion(name, region))
-            .filter(o -> o.getStatus() == Status.DEFAULT);
+            .filter(o -> o.getStatus() == DataStatus.DEFAULT);
     }
 
     @Cacheable(value = "terminals.region", key = "#region", cacheManager = "redisCacheManager")

--- a/src/main/java/com/younghun/hibusgo/service/BusTerminalService.java
+++ b/src/main/java/com/younghun/hibusgo/service/BusTerminalService.java
@@ -2,7 +2,7 @@ package com.younghun.hibusgo.service;
 
 
 import com.younghun.hibusgo.domain.BusTerminal;
-import com.younghun.hibusgo.domain.BusTerminal.Status;
+import com.younghun.hibusgo.domain.Status;
 import com.younghun.hibusgo.mapper.BusTerminalMapper;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/resources/mapper/account.xml
+++ b/src/main/resources/mapper/account.xml
@@ -66,8 +66,8 @@
     </select>
 
     <insert id="addAccount">
-        INSERT INTO ACCOUNT(user_id, password, name, phone_number, user_level, status, created_at)
-        VALUES(#{userId}, #{password}, #{name}, #{phoneNumber}, #{userLevel}, #{status}, #{createdAt})
+        INSERT INTO ACCOUNT(user_id, password, name, phone_number, user_level, status, created_at, updated_at)
+        VALUES(#{userId}, #{password}, #{name}, #{phoneNumber}, #{userLevel}, #{status}, #{createdAt}, #{createdAt})
     </insert>
 
     <update id="deleteAccount">

--- a/src/main/resources/mapper/busTerminal.xml
+++ b/src/main/resources/mapper/busTerminal.xml
@@ -63,12 +63,12 @@
         INNER JOIN REGION r
         ON b.region_id = r.id
         WHERE b.name = #{name}
-        AND status != 'DELETE'
+        AND b.status != 'DELETE'
     </select>
 
     <insert id="addBusTerminal">
-        INSERT INTO TERMINAL(name, address , tel , region_id, status)
-        VALUES(#{name}, #{address}, #{tel}, #{region_id} , #{status})
+        INSERT INTO TERMINAL (name, address , tel , region_id, status)
+        VALUES (#{name}, #{address}, #{tel}, #{region_id} , #{status})
     </insert>
 
     <update id="deleteBusTerminal">


### PR DESCRIPTION
중복된 Status enum을 제거하고 하나의 Status enum만 사용하도록 수정
사용하지 않는 import 제거
addAccount시 not null인 컬럼 추가하도록 수정
existsByName시 status가 어느 테이블의 것인지 명시