### PR TITLE
#51 세션 정보와 검색 정보를 담는 redis를 두개로 분리하여 저장 및 조회하도록 수정

### DIFF
--- a/src/main/java/com/younghun/hibusgo/config/RedisConfig.java
+++ b/src/main/java/com/younghun/hibusgo/config/RedisConfig.java
@@ -33,11 +33,11 @@ public class RedisConfig {
   private int port;
 
   // 캐시용 redis server host
-  @Value("${spring.redis.cacheHost}")
+  @Value("${spring.redis.cache.host}")
   private String cacheHost;
 
   // 캐시용 redis server port
-  @Value("${spring.redis.cachePort}")
+  @Value("${spring.redis.cache.port}")
   private int cachePort;
 
   /**
@@ -54,13 +54,13 @@ public class RedisConfig {
    * - TPS, 자원사용량 모두 Jedis에 비해 우수한 성능을 보인다는 테스트 사례가 있다.
    */
   @Primary
-  @Bean
-  public RedisConnectionFactory connectionFactory() {
+  @Bean("connectionSessionRedisFactory")
+  public RedisConnectionFactory connectionSessionRedisFactory() {
     return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
   }
 
-  @Bean
-  public RedisConnectionFactory connectionFactory2() {
+  @Bean("connectionCacheRedisFactory")
+  public RedisConnectionFactory connectionCacheRedisFactory() {
     return new LettuceConnectionFactory(new RedisStandaloneConfiguration(cacheHost, cachePort));
   }
 
@@ -75,7 +75,7 @@ public class RedisConfig {
   @Bean
   public RedisTemplate<Object, Object> redisTemplate() {
     RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
-    redisTemplate.setConnectionFactory(connectionFactory());
+    redisTemplate.setConnectionFactory(connectionSessionRedisFactory());
     redisTemplate.setKeySerializer(new StringRedisSerializer());
 
     //객체를 json 형태로 깨지지 않고 받기 위한 직렬화 작업
@@ -88,7 +88,7 @@ public class RedisConfig {
    * entryTtl - 캐시의 TTL(Time To Live)를 설정한다.
    */
   @Primary
-  @Bean
+  @Bean("cacheManager")
   public RedisCacheManager cacheManager() {
     RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
         .defaultCacheConfig()
@@ -101,14 +101,14 @@ public class RedisConfig {
 
     RedisCacheManager redisCacheManager = RedisCacheManager
         .RedisCacheManagerBuilder
-        .fromConnectionFactory(connectionFactory())
+        .fromConnectionFactory(connectionSessionRedisFactory())
         .cacheDefaults(redisCacheConfiguration)
         .build();
 
     return redisCacheManager;
   }
 
-  @Bean
+  @Bean("redisCacheManager")
   public RedisCacheManager redisCacheManager() {
     RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
         .defaultCacheConfig()
@@ -129,7 +129,7 @@ public class RedisConfig {
 
     RedisCacheManager redisCacheManager = RedisCacheManager
         .RedisCacheManagerBuilder
-        .fromConnectionFactory(connectionFactory2())
+        .fromConnectionFactory(connectionCacheRedisFactory())
         .cacheDefaults(redisCacheConfiguration)
         .build();
 

--- a/src/main/java/com/younghun/hibusgo/config/RedisConfig.java
+++ b/src/main/java/com/younghun/hibusgo/config/RedisConfig.java
@@ -54,13 +54,13 @@ public class RedisConfig {
    * - TPS, 자원사용량 모두 Jedis에 비해 우수한 성능을 보인다는 테스트 사례가 있다.
    */
   @Primary
-  @Bean("connectionSessionRedisFactory")
-  public RedisConnectionFactory connectionSessionRedisFactory() {
+  @Bean
+  public RedisConnectionFactory sessionRedisConnectionFactory() {
     return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
   }
 
-  @Bean("connectionCacheRedisFactory")
-  public RedisConnectionFactory connectionCacheRedisFactory() {
+  @Bean
+  public RedisConnectionFactory cacheRedisConnectionFactory() {
     return new LettuceConnectionFactory(new RedisStandaloneConfiguration(cacheHost, cachePort));
   }
 
@@ -75,7 +75,7 @@ public class RedisConfig {
   @Bean
   public RedisTemplate<Object, Object> redisTemplate() {
     RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
-    redisTemplate.setConnectionFactory(connectionSessionRedisFactory());
+    redisTemplate.setConnectionFactory(sessionRedisConnectionFactory());
     redisTemplate.setKeySerializer(new StringRedisSerializer());
 
     //객체를 json 형태로 깨지지 않고 받기 위한 직렬화 작업
@@ -88,7 +88,7 @@ public class RedisConfig {
    * entryTtl - 캐시의 TTL(Time To Live)를 설정한다.
    */
   @Primary
-  @Bean("cacheManager")
+  @Bean
   public RedisCacheManager cacheManager() {
     RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
         .defaultCacheConfig()
@@ -101,14 +101,14 @@ public class RedisConfig {
 
     RedisCacheManager redisCacheManager = RedisCacheManager
         .RedisCacheManagerBuilder
-        .fromConnectionFactory(connectionSessionRedisFactory())
+        .fromConnectionFactory(sessionRedisConnectionFactory())
         .cacheDefaults(redisCacheConfiguration)
         .build();
 
     return redisCacheManager;
   }
 
-  @Bean("redisCacheManager")
+  @Bean
   public RedisCacheManager redisCacheManager() {
     RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
         .defaultCacheConfig()
@@ -129,7 +129,7 @@ public class RedisConfig {
 
     RedisCacheManager redisCacheManager = RedisCacheManager
         .RedisCacheManagerBuilder
-        .fromConnectionFactory(connectionCacheRedisFactory())
+        .fromConnectionFactory(cacheRedisConnectionFactory())
         .cacheDefaults(redisCacheConfiguration)
         .build();
 

--- a/src/main/java/com/younghun/hibusgo/config/RedisConfig.java
+++ b/src/main/java/com/younghun/hibusgo/config/RedisConfig.java
@@ -26,11 +26,11 @@ public class RedisConfig {
 
   // 세션용 redis server host
   @Value("${spring.redis.host}")
-  private String host;
+  private String sessionHost;
 
   // 세션용 redis server port
   @Value("${spring.redis.port}")
-  private int port;
+  private int sessionPort;
 
   // 캐시용 redis server host
   @Value("${spring.redis.cache.host}")
@@ -56,7 +56,7 @@ public class RedisConfig {
   @Primary
   @Bean
   public RedisConnectionFactory sessionRedisConnectionFactory() {
-    return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    return new LettuceConnectionFactory(new RedisStandaloneConfiguration(sessionHost, sessionPort));
   }
 
   @Bean
@@ -89,7 +89,7 @@ public class RedisConfig {
    */
   @Primary
   @Bean
-  public RedisCacheManager cacheManager() {
+  public RedisCacheManager cacheManager(RedisConnectionFactory sessionRedisConnectionFactory) {
     RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
         .defaultCacheConfig()
         .serializeKeysWith(RedisSerializationContext
@@ -101,7 +101,7 @@ public class RedisConfig {
 
     RedisCacheManager redisCacheManager = RedisCacheManager
         .RedisCacheManagerBuilder
-        .fromConnectionFactory(sessionRedisConnectionFactory())
+        .fromConnectionFactory(sessionRedisConnectionFactory)
         .cacheDefaults(redisCacheConfiguration)
         .build();
 
@@ -109,7 +109,7 @@ public class RedisConfig {
   }
 
   @Bean
-  public RedisCacheManager redisCacheManager() {
+  public RedisCacheManager redisCacheManager(RedisConnectionFactory cacheRedisConnectionFactory) {
     RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
         .defaultCacheConfig()
         .serializeKeysWith(RedisSerializationContext
@@ -129,7 +129,7 @@ public class RedisConfig {
 
     RedisCacheManager redisCacheManager = RedisCacheManager
         .RedisCacheManagerBuilder
-        .fromConnectionFactory(cacheRedisConnectionFactory())
+        .fromConnectionFactory(cacheRedisConnectionFactory)
         .cacheDefaults(redisCacheConfiguration)
         .build();
 

--- a/src/main/java/com/younghun/hibusgo/service/BusTerminalService.java
+++ b/src/main/java/com/younghun/hibusgo/service/BusTerminalService.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 
@@ -30,18 +29,18 @@ public class BusTerminalService {
      * 만약 동일 key 값이 없을 경우 메소드를 실행하고 반환된 결과 값을 Cache에 저장합니다.
      * unless = "#result == null" -> 조회 결과 값이 null이 아닐 경우에만 캐싱
      */
-    @Cacheable(value = CacheKeys.TERMINAL_NAME, key = "#name", cacheManager = "redisCacheManager")
+    @Cacheable(value = CacheKeys.TERMINALS_NAME, key = "#name", cacheManager = "redisCacheManager")
     public Optional<BusTerminal> findByNameAndRegion(String name, String region) {
         return Optional.ofNullable(terminalMapper.findByNameAndRegion(name, region))
             .filter(o -> o.getStatus() == DataStatus.DEFAULT);
     }
 
-    @Cacheable(value = CacheKeys.TERMINAL_REGION, key = "#region", cacheManager = "redisCacheManager")
+    @Cacheable(value = CacheKeys.TERMINALS_REGION, key = "#region", cacheManager = "redisCacheManager")
     public List<BusTerminal> searchByRegion(String region) {
         return terminalMapper.searchByRegion(region);
     }
 
-    @Cacheable(value = CacheKeys.TERMINAL_TOTAL, key = "'total'", cacheManager = "redisCacheManager")
+    @Cacheable(value = CacheKeys.TERMINALS_TOTAL, key = "'total'", cacheManager = "redisCacheManager")
     public List<BusTerminal> searchTotal() {
         return terminalMapper.searchTotal();
     }

--- a/src/main/java/com/younghun/hibusgo/service/RegionService.java
+++ b/src/main/java/com/younghun/hibusgo/service/RegionService.java
@@ -1,5 +1,8 @@
 package com.younghun.hibusgo.service;
 
+import static com.younghun.hibusgo.utils.CacheKeys.REGIONS_NAME;
+import static com.younghun.hibusgo.utils.CacheKeys.REGIONS_TOTAL;
+
 import com.younghun.hibusgo.domain.Region;
 import com.younghun.hibusgo.mapper.RegionMapper;
 import java.util.List;
@@ -32,13 +35,12 @@ public class RegionService {
    * @Cacheable : 동일 값이 Cache에 있는 경우 Cache에서 데이터를 return합니다.
    * 만약 동일 key 값이 없을 경우 메소드를 실행하고 반환된 결과 값을 Cache에 저장합니다.
    */
-  @Cacheable(value = "regions.name", key = "#name", cacheManager = "redisCacheManager")
+  @Cacheable(value = REGIONS_NAME, key = "#name", cacheManager = "redisCacheManager")
   public List<Region> searchByName(String name) {
     return regionMapper.searchByName(name);
   }
 
-  @Scheduled(fixedDelay = 300000L) // 5분마다 캐시 갱신
-  @Cacheable(value = "regions.total", key = "'total'")
+  @Cacheable(value = REGIONS_TOTAL, key = "'total'", cacheManager = "redisCacheManager")
   public List<Region> searchTotal() {
     return regionMapper.searchTotal();
   }

--- a/src/main/java/com/younghun/hibusgo/utils/CacheKeys.java
+++ b/src/main/java/com/younghun/hibusgo/utils/CacheKeys.java
@@ -9,7 +9,9 @@ package com.younghun.hibusgo.utils;
  *  이러한 이유로 새로운 객체롤 최대한 적게 생성하도록 지향.
  */
 public class CacheKeys {
-  public static final String TERMINAL_NAME = "terminals.name";
-  public static final String TERMINAL_REGION = "terminals.region";
-  public static final String TERMINAL_TOTAL = "terminals.total";
+  public static final String TERMINALS_NAME = "terminals.name";
+  public static final String TERMINALS_REGION = "terminals.region";
+  public static final String TERMINALS_TOTAL = "terminals.total";
+  public static final String REGIONS_NAME = "regions.name";
+  public static final String REGIONS_TOTAL = "regions.total";
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,5 +26,5 @@ spring.redis.port=6379
 spring.redis.timeout=360000
 
 #redis 설정(조회 정보 캐시용)
-spring.redis.cacheHost=localhost
-spring.redis.cachePort=6389
+spring.redis.cache.host=localhost
+spring.redis.cache.port=6389

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,9 +18,13 @@ mybatis.mapper-locations=classpath:mapper/*.xml
 # 추가 목적 : 개발 단계에서 메소드를 추적하여 전체적인 흐름 및 정보를 보기 위해 추가
 logging.level.net.com.younghun.hibusgo.mapper=TRACE
 
-# redis 설정
+# redis 설정(세션 캐시용)
 spring.redis.database=0
 spring.redis.host=localhost
 spring.redis.password=
 spring.redis.port=6379
 spring.redis.timeout=360000
+
+#redis 설정(조회 정보 캐시용)
+spring.redis.cacheHost=localhost
+spring.redis.cachePort=6389


### PR DESCRIPTION
세션 정보를 담는 redis와 조회 캐시 정보를 담는 redis에 나눠서 저장하도록 수정
접속 정보(host, port) 수정

커넥션 빈 캐시 매니져를 redis에 맞게 각각 설정 및 추가
지역 정보 static 변수 추가